### PR TITLE
Requires celluloid before requiring sidekiq/fetch

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "rspec"
 
+require 'celluloid'
 require 'sidekiq'
 require 'sidekiq/processor'
 require 'sidekiq/manager'


### PR DESCRIPTION
Requires celluloid before requiring sidekiq/fetch to avoid this error: https://github.com/brainopia/sidekiq-limit_fetch/pull/5

```
$ rspec spec/
/Users/fred/.rvm/gems/ruby-2.0.0-p247/gems/sidekiq-2.12.4/lib/sidekiq/actor.rb:4:in `included': uninitialized constant Sidekiq::Actor::Celluloid (NameError)
```
