### PR TITLE
Updated readme to include client middleware in configure_server block

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
     chain.add Sidekiq::Status::ServerMiddleware, expiration: 30.minutes # default
   end
+  config.client_middleware do |chain|
+    chain.add Sidekiq::Status::ClientMiddleware
+  end
 end
 ```
 


### PR DESCRIPTION
If you create jobs within your jobs, they will not have status info unless you include the client middleware in the configure_server block. I believe this should be in the example in the Readme.
