### PR TITLE
Rename pct_complete to percent_complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ end
 job_id = MyJob.perform_async(*args)
 data = Sidekiq::Status::get_all job_id
 data # => {status: 'complete', update_time: 1360006573, vino: 'veritas'}
-Sidekiq::Status::get     job_id, :vino #=> 'veritas'
-Sidekiq::Status::at      job_id #=> 5
-Sidekiq::Status::total   job_id #=> 100
-Sidekiq::Status::message job_id #=> "Almost done"
-Sidekiq::Status::pct_complete job_id #=> 5
+Sidekiq::Status::get              job_id, :vino #=> 'veritas'
+Sidekiq::Status::at               job_id #=> 5
+Sidekiq::Status::total            job_id #=> 100
+Sidekiq::Status::message          job_id #=> "Almost done"
+Sidekiq::Status::percent_complete job_id #=> 5
 ```
 ### Unscheduling
 

--- a/lib/sidekiq-status.rb
+++ b/lib/sidekiq-status.rb
@@ -51,7 +51,7 @@ module Sidekiq::Status
       get(job_id, :total).to_i
     end
 
-    def pct_complete(job_id)
+    def percent_complete(job_id)
       (at(job_id).to_f / total(job_id)) * 100
     end
 

--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -26,7 +26,7 @@ module Sidekiq::Status
           status["worker"] = job.klass
           status["args"] = job.args
           status["jid"] = job.jid
-          status["pct_complete"] = ((status["at"].to_f / status["total"].to_f) * 100).to_i if status["total"].to_f > 0
+          status["percent_complete"] = ((status["at"].to_f / status["total"].to_f) * 100).to_i if status["total"].to_f > 0
           @statuses << OpenStruct.new(status)
         end
 

--- a/spec/lib/sidekiq-status_spec.rb
+++ b/spec/lib/sidekiq-status_spec.rb
@@ -48,7 +48,7 @@ describe Sidekiq::Status do
     end
   end
 
-  describe ".at, .total, .pct_complete, .message" do
+  describe ".at, .total, .percent_complete, .message" do
     it "should return job progress with correct type to it" do
       allow(SecureRandom).to receive(:hex).once.and_return(job_id)
 
@@ -59,8 +59,8 @@ describe Sidekiq::Status do
       end
       expect(Sidekiq::Status.at(job_id)).to be(100)
       expect(Sidekiq::Status.total(job_id)).to be(500)
-      # It returns a float therefor we need eq()
-      expect(Sidekiq::Status.pct_complete(job_id)).to eq(20)
+      # It returns a float therefore we need eq()
+      expect(Sidekiq::Status.percent_complete(job_id)).to eq(20)
       expect(Sidekiq::Status.message(job_id)).to eq('howdy, partner?')
     end
   end

--- a/web/views/statuses.erb
+++ b/web/views/statuses.erb
@@ -20,9 +20,9 @@
       <td><%= Time.at(container.update_time.to_i) %></td>
       <td>
         <div class="progress progress-striped" style="margin-bottom: 0">
-          <div class="bar" style="width: <%= container.pct_complete %>%; text-shadow: 1px 1px 1px black; background-color: #AD003D;
+          <div class="bar" style="width: <%= container.percent_complete %>%; text-shadow: 1px 1px 1px black; background-color: #AD003D;
 color: white;">
-            <%= container.pct_complete %>%
+            <%= container.percent_complete %>%
           </div>
         </div>
       <td><%= container.message %></td>


### PR DESCRIPTION
`pct_complete` is a poor name.

I was also tempted to rename it to `percent` but I think the `_complete` part is important.