### PR TITLE
Sidekiq 2 web compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
 rvm:
   - 2.1.0
+gemfile:
+  - gemfiles/Gemfile.sidekiq-2
+  - Gemfile
 services: redis

--- a/gemfiles/Gemfile.sidekiq-2
+++ b/gemfiles/Gemfile.sidekiq-2
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem 'sidekiq', '~> 2.17'

--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -19,7 +19,13 @@ module Sidekiq::Status
         queue = Sidekiq::Workers.new
         @statuses = []
 
-        queue.each do |process, name, work, started_at|
+        queue.each do |*args|
+          work = if args[1].is_a?(Hash)
+            # For sidekiq < 3
+            args[1]
+          else
+            args[2]
+          end
           job = Struct.new(:jid, :klass, :args).new(work["payload"]["jid"], work["payload"]["class"], work["payload"]["args"])
           status = Sidekiq::Status::get_all job.jid
           next if !status || status.count < 2

--- a/sidekiq-status.gemspec
+++ b/sidekiq-status.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |gem|
   gem.version       = Sidekiq::Status::VERSION
 
   gem.add_dependency                  'sidekiq', '>= 2.7', '< 3.4'
+  gem.add_development_dependency      'rack-test'
   gem.add_development_dependency      'rake'
   gem.add_development_dependency      'rspec'
+  gem.add_development_dependency      'sinatra'
 end

--- a/spec/lib/sidekiq-status/web_spec.rb
+++ b/spec/lib/sidekiq-status/web_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'sidekiq-status/web'
+require 'rack/test'
+
+describe 'sidekiq status web' do
+  include Rack::Test::Methods
+
+  let!(:redis) { Sidekiq.redis { |conn| conn } }
+  let!(:job_id) { SecureRandom.hex(12) }
+
+  # Clean Redis before each test
+  # Seems like flushall has no effect on recently published messages,
+  # so we should wait till they expire
+  before { redis.flushall; sleep 0.1 }
+
+  def app
+    Sidekiq::Web
+  end
+
+  it 'shows a job in progress' do
+    allow(SecureRandom).to receive(:hex).once.and_return(job_id)
+
+    start_server do
+      capture_status_updates(2) do
+        expect(LongJob.perform_async(1)).to eq(job_id)
+      end
+
+      get '/statuses'
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to match(/#{job_id}/)
+    end
+  end
+
+end


### PR DESCRIPTION
When iterating over the workers, Sidekiq 2 yielded the name, work hash, and started_at timestamp. Sidekiq 3 yields the process_id, thread_id, and work hash.

Travis is also updated so both Sidekiq 2 and 3 are tested.