### PR TITLE
Remove version limitation on sidekiq

### DIFF
--- a/sidekiq-status.gemspec
+++ b/sidekiq-status.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Sidekiq::Status::VERSION
 
-  gem.add_dependency                  'sidekiq', '>= 2.7', '< 3.4'
+  gem.add_dependency                  'sidekiq', '>= 2.7'
   gem.add_development_dependency      'rack-test'
   gem.add_development_dependency      'rake'
   gem.add_development_dependency      'rspec'


### PR DESCRIPTION
I can't update to the latest sidekiq version because `sidekiq-status` wants `< 3.4`. The tests seem to still run even with `sidekiq 3.4.1`.

I think it'd be better to lock the sidekiq version if there's ever an incompatibility problem. Otherwise we'll have this problem on every new version.