### PR TITLE
Added way to specify :expiration for Sidekiq::Status::ClientMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,19 @@ require 'sidekiq-status'
 
 Sidekiq.configure_client do |config|
   config.client_middleware do |chain|
-    chain.add Sidekiq::Status::ClientMiddleware
+    # accepts :expiration (optional)
+    chain.add Sidekiq::Status::ClientMiddleware, expiration: 30.minutes # default
   end
 end
 
 Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
+    # accepts :expiration (optional)
     chain.add Sidekiq::Status::ServerMiddleware, expiration: 30.minutes # default
   end
   config.client_middleware do |chain|
-    chain.add Sidekiq::Status::ClientMiddleware
+    # accepts :expiration (optional)
+    chain.add Sidekiq::Status::ClientMiddleware, expiration: 30.minutes # default
   end
 end
 ```

--- a/lib/sidekiq-status/client_middleware.rb
+++ b/lib/sidekiq-status/client_middleware.rb
@@ -2,13 +2,22 @@ module Sidekiq::Status
 # Should be in the client middleware chain
   class ClientMiddleware
     include Storage
+
+    # Parameterized initialization, use it when adding middleware to client chain
+    # chain.add Sidekiq::Status::ClientMiddleware, :expiration => 60 * 5
+    # @param [Hash] opts middleware initialization options
+    # @option opts [Fixnum] :expiration ttl for complete jobs
+    def initialize(opts = {})
+      @expiration = opts[:expiration]
+    end
+
     # Uses msg['jid'] id and puts :queued status in the job's Redis hash
     # @param [Class] worker_class if includes Sidekiq::Status::Worker, the job gets processed with the plugin
     # @param [Array] msg job arguments
     # @param [String] queue the queue's name
     # @param [ConnectionPool] redis_pool optional redis connection pool
     def call(worker_class, msg, queue, redis_pool=nil)
-      store_status msg['jid'], :queued, nil, redis_pool
+      store_status msg['jid'], :queued, @expiration, redis_pool
       yield
     end
   end

--- a/spec/lib/sidekiq-status/server_middleware_spec.rb
+++ b/spec/lib/sidekiq-status/server_middleware_spec.rb
@@ -62,7 +62,9 @@ describe Sidekiq::Status::ServerMiddleware do
 
     it "sets status hash ttl" do
       allow(SecureRandom).to receive(:hex).once.and_return(job_id)
-      expect(StubJob.perform_async(:arg1 => 'val1')).to eq(job_id)
+      start_server do
+        expect(StubJob.perform_async(:arg1 => 'val1')).to eq(job_id)
+      end
       expect(1..Sidekiq::Status::DEFAULT_EXPIRY).to cover redis.ttl("sidekiq:status:#{job_id}")
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,9 +9,11 @@ require 'sidekiq-status'
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
-Sidekiq.configure_client do |config|
-  config.client_middleware do |chain|
-    chain.add Sidekiq::Status::ClientMiddleware
+def client_middleware(client_middleware_options={}) 
+  Sidekiq.configure_client do |config|
+    config.client_middleware do |chain|
+      chain.add Sidekiq::Status::ClientMiddleware, client_middleware_options
+    end
   end
 end
 


### PR DESCRIPTION
Fixes #41
+ Now Sidekiq::Status::ClientMiddleware, can accept :expiration args
+ Added/Updated test cases for this change
+ Updated README to reflect this change