### PR TITLE
Stub Sidekiq::Storage#store_status

### DIFF
--- a/lib/sidekiq-status/testing/inline.rb
+++ b/lib/sidekiq-status/testing/inline.rb
@@ -6,5 +6,11 @@ module Sidekiq
       end
     end
   end
+  
+  module Storage
+    def store_status(id, status, expiration = nil, redis_pool=nil)
+      'ok'
+    end
+  end
 end
 


### PR DESCRIPTION
Currently including `require 'sidekiq-status/testing/inline'` in my project won't stub store_status. That means that it will still try to connect to Redis, and will generate an error when I don't have Redis running locally.

Using this patch store_status returns an 'ok' string instead of trying to connect to Redis. A more appropriate simulation of Redis response codes is likely necessary.

THIS CODE IS NOT TESTED. (Other than that I tried it out in the console).
