### PR TITLE
Feature: Added all job statuses to Sidekiq::Status::Web fixes #44

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Important: If you try any of the status method after the expiration time for sch
 
 ### Sidekiq web integration
 
-Sidekiq::Status also provides an extension to Sidekiq web interface with a `/statuses` page.
+Sidekiq::Status also provides an extension to Sidekiq web interface with a `/statuses` [page](https://drive.google.com/file/d/0Bx956Uwn4a8wZlBxeVpMTlJZdkk/view?usp=sharing).
 
 Setup Sidekiq web interface according to Sidekiq documentation and add the Sidekiq::Status::Web require:
 

--- a/lib/sidekiq-status/client_middleware.rb
+++ b/lib/sidekiq-status/client_middleware.rb
@@ -17,7 +17,13 @@ module Sidekiq::Status
     # @param [String] queue the queue's name
     # @param [ConnectionPool] redis_pool optional redis connection pool
     def call(worker_class, msg, queue, redis_pool=nil)
-      store_status msg['jid'], :queued, @expiration, redis_pool
+      initial_metadata = { 
+        jid: msg['jid'],
+        status: :queued,
+        worker: worker_class, 
+        args: msg['args'].to_a.empty? ? nil : msg['args']
+      }
+      store_for_id msg['jid'], initial_metadata, @expiration, redis_pool
       yield
     end
   end

--- a/spec/lib/sidekiq-status/web_spec.rb
+++ b/spec/lib/sidekiq-status/web_spec.rb
@@ -18,6 +18,7 @@ describe 'sidekiq status web' do
   end
 
   it 'shows a job in progress' do
+    client_middleware
     allow(SecureRandom).to receive(:hex).and_return(job_id)
 
     start_server do
@@ -27,8 +28,9 @@ describe 'sidekiq status web' do
 
       get '/statuses'
       expect(last_response).to be_ok
-      # TODO - Fix this
-      # expect(last_response.body).to match(/#{job_id}/)
+      expect(last_response.body).to match(/#{job_id}/)
+      expect(last_response.body).to match(/LongJob/)
+      expect(last_response.body).to match(/working/)
     end
   end
 

--- a/web/views/statuses.erb
+++ b/web/views/statuses.erb
@@ -19,6 +19,7 @@
 <table class="table table-striped table-bordered">
   <tr>
     <th>Worker/jid</th>
+    <th style='text-align:center;'>Arguments</th>
     <th style='text-align:center;'>Status</th>
     <th style='width: 10%; text-align:center;'>Last Updated</th>
     <th style='width: 50%;'>Progress</th>
@@ -26,7 +27,10 @@
   <% @statuses.each do |container| %>
     <tr>
       <td><span title='<%= container.jid %>'><%= container.worker %></span></td>
-      <td style='text-align: center;'><span class='badge'><%= container.status %></span></td>
+      <td><span title='<%= container.jid %>'><%= container.args %></span></td>
+      <td style='text-align: center;'>
+        <span class='label label-<%= container.label %>'><%= container.status %></span>
+      </td>
       <% secs = Time.now.to_i - container.update_time.to_i %>
       <td style='text-align: center;'>
         <% if secs > 0 %>


### PR DESCRIPTION
- Sidekiq::Status::Web now will have all job statuses, previously it was showing only :working status
- Updated Sidekiq::Status::Web UI to use bootstrap lables instead of badges
- Added Arguments column to Updated Sidekiq::Status::Web UI
- Now Web UI looks lot more better, you can see sample  [page](https://drive.google.com/file/d/0Bx956Uwn4a8wZlBxeVpMTlJZdkk/view?usp=sharing).