### PR TITLE
feature/all_jobs_or_only_sidekiq_status_workers

### DIFF
--- a/spec/lib/sidekiq-status/server_middleware_spec.rb
+++ b/spec/lib/sidekiq-status/server_middleware_spec.rb
@@ -91,4 +91,33 @@ describe Sidekiq::Status::ServerMiddleware do
       expect((huge_expiration+1)..overwritten_expiration).to cover redis.ttl("sidekiq:status:#{job_id}")
     end
   end
+
+  describe ":all_jobs parameter" do
+    let!(:ordinary_job_id) { SecureRandom.hex(12) }
+    let!(:status_job_id) { SecureRandom.hex(12) }
+
+    it "should track status for all jobs" do
+      allow(SecureRandom).to receive(:hex).and_return(ordinary_job_id, status_job_id)
+      start_server(all_jobs: true) do
+        expect(OrdinaryJob.perform_async(:arg1 => 'val1')).to eq ordinary_job_id
+        expect(StubJob.perform_async(:arg1 => 'val1')).to eq status_job_id
+      end
+      expect(redis.hget("sidekiq:status:#{ordinary_job_id}", :status)).to eq('complete')
+      expect(redis.hget("sidekiq:status:#{status_job_id}", :status)).to eq('complete')
+      expect(Sidekiq::Status::complete?(ordinary_job_id)).to be_truthy
+      expect(Sidekiq::Status::complete?(status_job_id)).to be_truthy
+    end
+
+    it "should only track status of Sidekiq::Status::Worker" do
+      allow(SecureRandom).to receive(:hex).and_return(ordinary_job_id, status_job_id)
+      start_server(all_jobs: false) do
+        expect(OrdinaryJob.perform_async(:arg1 => 'val1')).to eq ordinary_job_id
+        expect(StubJob.perform_async(:arg1 => 'val1')).to eq status_job_id
+      end
+      expect(redis.hget("sidekiq:status:#{ordinary_job_id}", :status)).to be_nil
+      expect(redis.hget("sidekiq:status:#{status_job_id}", :status)).to eq('complete')
+      expect(Sidekiq::Status::complete?(ordinary_job_id)).to be_falsey
+      expect(Sidekiq::Status::complete?(status_job_id)).to be_truthy
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "rspec"
 
-require 'celluloid'
+require 'celluloid/current'
 require 'sidekiq'
 require 'sidekiq/processor'
 require 'sidekiq/manager'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "rspec"
 
-require 'celluloid/current'
+require 'celluloid'
 require 'sidekiq'
 require 'sidekiq/processor'
 require 'sidekiq/manager'

--- a/spec/support/test_jobs.rb
+++ b/spec/support/test_jobs.rb
@@ -79,3 +79,12 @@ class RetriedJob < StubJob
     end
   end
 end
+
+class OrdinaryJob
+  include Sidekiq::Worker
+
+  sidekiq_options 'retry' => 'false'
+
+  def perform(*args)
+  end
+end


### PR DESCRIPTION
Changes to support having Sidekiq::Status only track the status of jobs specifically including Sidekiq::Status::Worker for use where only the status of certain jobs matter and to reduce the Redis memory usage.
