### PR TITLE
Bug fixed. sort_by caused an OpenStruct comparation exception

### DIFF
--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -58,11 +58,16 @@ module Sidekiq::Status
         sort_by = has_sort_by?(params[:sort_by]) ? params[:sort_by] : "update_time"
         sort_dir = "asc"
 
-        if params[:sort_dir] == "asc"
-          @statuses = @statuses.sort { |x,y| x.send(sort_by) <=> y.send(sort_by) }
-        else
-          sort_dir = "desc"
-          @statuses = @statuses.sort { |y,x| x.send(sort_by) <=> y.send(sort_by) }
+        begin
+          if params[:sort_dir] == "asc"
+            @statuses = @statuses.sort { |x,y| x.send(sort_by) <=> y.send(sort_by) }
+          else
+            sort_dir = "desc"
+            @statuses = @statuses.sort { |y,x| x.send(sort_by) <=> y.send(sort_by) }
+          end          
+        rescue Exception => e
+          #sort_by key must exists in every status object or #sort will crash, 
+          #so we just catch the exception to prevent UI errors
         end
 
         working_jobs = @statuses.select{|job| job.status == "working"}


### PR DESCRIPTION
Sidekiq::Status was causing this error in the UI panel:

```
 ArgumentError - comparison of OpenStruct with OpenStruct failed:
        /var/www/my_project/shared/bundle/ruby/2.2.0/gems/sidekiq-status-0.6.0/lib/sidekiq-status/web.rb:65:in `sort'
```

The problem occurs when the **sort_by** key is not in every sidekiq:status object to be compared.  

In my case, Redis data looks corrupted, in the example below the second job have only **at**  and **message** keys , so sort by "update_at" raise the exception.

```
127.0.0.1:6379[1]> hgetall "sidekiq:status:6e61cc4b2d0cfd21adf1bd0c"
 1) "worker"
 2) "ImagesWorker::AttachToProducts"
 3) "at"
 4) "6017"
 5) "jid"
 6) "6e61cc4b2d0cfd21adf1bd0c"
 7) "total"
 8) "6992"
 9) "update_time"
10) "1468329930"
11) "status"
12) "queued"
13) "args"
14) ""
15) "message"
16) "(6017/6992) Processing 3380814227716-2.jpg ... "


127.0.0.1:6379[1]> hgetall "sidekiq:status:2eef044af31ea3c4646fb359"
1) "at"
2) "21806"
3) "message"
4) "1. Loading new products (21806/21806)"

```
