### PR TITLE
All jobs or only sidekiq status workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,18 @@ require 'sidekiq-status'
 
 Sidekiq.configure_client do |config|
   config.client_middleware do |chain|
-    # accepts :expiration (optional)
+    # accepts :expiration (optional), :all_jobs (optional, defaults true)
     chain.add Sidekiq::Status::ClientMiddleware, expiration: 30.minutes # default
   end
 end
 
 Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
-    # accepts :expiration (optional)
+    # accepts :expiration (optional), :all_jobs (optional, defaults true)
     chain.add Sidekiq::Status::ServerMiddleware, expiration: 30.minutes # default
   end
   config.client_middleware do |chain|
-    # accepts :expiration (optional)
+    # accepts :expiration (optional), :all_jobs (optional, defaults true)
     chain.add Sidekiq::Status::ClientMiddleware, expiration: 30.minutes # default
   end
 end
@@ -61,6 +61,32 @@ class MyJob
 
   def perform(*args)
   # your code goes here
+  end
+end
+```
+
+As a default, status will be tracked for all Sidekiq jobs even those without the `Sidekiq::Status::Worker` module included in your worker class. 
+To override this behavior and track status only for Sidekiq workers including the `Sidekiq::Status::Worker` module you can initialize the Sidekiq::Status middleware using the all_jobs: parameter like this below:
+
+``` ruby
+require 'sidekiq'
+require 'sidekiq-status'
+
+Sidekiq.configure_client do |config|
+  config.client_middleware do |chain|
+    # accepts :expiration (optional), :all_jobs (optional and defaults true)
+    chain.add Sidekiq::Status::ClientMiddleware, all_jobs: false
+  end
+end
+
+Sidekiq.configure_server do |config|
+  config.server_middleware do |chain|
+    # accepts :expiration (optional), :all_jobs (optional and defaults true)
+    chain.add Sidekiq::Status::ServerMiddleware, all_jobs: false
+  end
+  config.client_middleware do |chain|
+    # accepts :expiration (optional), :all_jobs (optional and defaults true)
+    chain.add Sidekiq::Status::ClientMiddleware, all_jobs: false
   end
 end
 ```
@@ -106,7 +132,8 @@ Sidekiq::Status::failed?      job_id
 Sidekiq::Status::interrupted? job_id
 
 ```
-Important: If you try any of the above status method after the expiration time, will result into `nil` or `false` 
+
+Important: If you try any of the above status methods after the expiration time OR if you try to obtain status for job that is not being tracked (see :all_jobs initialization above) it will result in `nil` or `false`
 
 ### Tracking progress, saving, and retrieving data associated with job
 

--- a/lib/sidekiq-status/client_middleware.rb
+++ b/lib/sidekiq-status/client_middleware.rb
@@ -8,8 +8,12 @@ module Sidekiq::Status
     # chain.add Sidekiq::Status::ClientMiddleware, :expiration => 60 * 5
     # @param [Hash] opts middleware initialization options
     # @option opts [Fixnum] :expiration ttl for complete jobs
+    # @option opts [boolean] :all_jobs indicates all jobs should have status (default: true)
     def initialize(opts = {})
+      default_opts = {expiration: nil, all_jobs: true}
+      opts = default_opts.merge(opts)
       @expiration = opts[:expiration]
+      @all_jobs = opts[:all_jobs]
     end
 
     # Uses msg['jid'] id and puts :queued status in the job's Redis hash
@@ -18,14 +22,23 @@ module Sidekiq::Status
     # @param [String] queue the queue's name
     # @param [ConnectionPool] redis_pool optional redis connection pool
     def call(worker_class, msg, queue, redis_pool=nil)
-      initial_metadata = {
-        jid: msg['jid'],
-        status: :queued,
-        worker: worker_class,
-        args: display_args(msg, queue)
-      }
-      store_for_id msg['jid'], initial_metadata, @expiration, redis_pool
+      if @all_jobs || is_sidekiq_status_worker?(worker_class)
+        initial_metadata = {
+          jid: msg['jid'],
+          status: :queued,
+          worker: worker_class,
+          args: display_args(msg, queue)
+        }
+        store_for_id msg['jid'], initial_metadata, @expiration, redis_pool
+      end
       yield
+    end
+
+    private
+
+    def is_sidekiq_status_worker?(worker_class)
+      worker_class = Module.const_get(worker_class) if worker_class.is_a?(String)
+      worker_class.ancestors.include?(Sidekiq::Status::Worker)
     end
 
     def display_args(msg, queue)

--- a/spec/lib/sidekiq-status/server_middleware_spec.rb
+++ b/spec/lib/sidekiq-status/server_middleware_spec.rb
@@ -91,4 +91,33 @@ describe Sidekiq::Status::ServerMiddleware do
       expect((huge_expiration+1)..overwritten_expiration).to cover redis.ttl("sidekiq:status:#{job_id}")
     end
   end
+
+  describe ":all_jobs parameter" do
+    let!(:ordinary_job_id) { SecureRandom.hex(12) }
+    let!(:status_job_id) { SecureRandom.hex(12) }
+
+    it "should track status for all jobs" do
+      allow(SecureRandom).to receive(:hex).and_return(ordinary_job_id, status_job_id)
+      start_server(all_jobs: true) do
+        expect(OrdinaryJob.perform_async(:arg1 => 'val1')).to eq ordinary_job_id
+        expect(StubJob.perform_async(:arg1 => 'val1')).to eq status_job_id
+      end
+      expect(redis.hget("sidekiq:status:#{ordinary_job_id}", :status)).to eq('complete')
+      expect(redis.hget("sidekiq:status:#{status_job_id}", :status)).to eq('complete')
+      expect(Sidekiq::Status::complete?(ordinary_job_id)).to be_truthy
+      expect(Sidekiq::Status::complete?(status_job_id)).to be_truthy
+    end
+
+    it "should only track status of Sidekiq::Status::Worker" do
+      allow(SecureRandom).to receive(:hex).and_return(ordinary_job_id, status_job_id)
+      start_server(all_jobs: false) do
+        expect(OrdinaryJob.perform_async(:arg1 => 'val1')).to eq ordinary_job_id
+        expect(StubJob.perform_async(:arg1 => 'val1')).to eq status_job_id
+      end
+      expect(redis.hget("sidekiq:status:#{ordinary_job_id}", :status)).to be_nil
+      expect(redis.hget("sidekiq:status:#{status_job_id}", :status)).to eq('complete')
+      expect(Sidekiq::Status::complete?(ordinary_job_id)).to be_falsey
+      expect(Sidekiq::Status::complete?(status_job_id)).to be_truthy
+    end
+  end
 end

--- a/spec/support/test_jobs.rb
+++ b/spec/support/test_jobs.rb
@@ -79,3 +79,12 @@ class RetriedJob < StubJob
     end
   end
 end
+
+class OrdinaryJob
+  include Sidekiq::Worker
+
+  sidekiq_options 'retry' => 'false'
+
+  def perform(*args)
+  end
+end


### PR DESCRIPTION
Changes to support having Sidekiq::Status only track the status of jobs specifically including Sidekiq::Status::Worker for use where only the status of certain jobs matter and to reduce the Redis memory usage.
