### PR TITLE
Fix jid/arguments/status not showing in statuses

### DIFF
--- a/lib/sidekiq-status.rb
+++ b/lib/sidekiq-status.rb
@@ -23,7 +23,7 @@ module Sidekiq::Status
     # @params [String] id job id returned by async_perform
     # @return [Hash] hash of all fields stored for the job
     def get_all(job_id)
-      read_hash_for_id(job_id)
+      read_hash_for_id(job_id).merge(jid: job_id
     end
 
     def status(job_id)


### PR DESCRIPTION
Adds jid to `Sidekiq::Status.get_all`. Without it, it was not able to get the percent complete, even though all the information was already there