### PR TITLE
using max_items parameter to limit the number of displayed jobs

### DIFF
--- a/lib/sidekiq-status/version.rb
+++ b/lib/sidekiq-status/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Status
-    VERSION = '0.6.0'
+    VERSION = '0.7.0'
   end
 end

--- a/lib/sidekiq-status/version.rb
+++ b/lib/sidekiq-status/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Status
-    VERSION = '0.7.0'
+    VERSION = '0.6.0'
   end
 end

--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -48,7 +48,17 @@ module Sidekiq::Status
         jids = namespace_jids.map{|id_namespace| id_namespace.split(':').last }
         @statuses = []
 
-        jids.each do |jid|
+        if params[:max_items] == 'all'
+          @max_items = 'all' if params[:max_items] == 'all'
+          max_items = jids.size if @max_items == 'all'
+        else
+          is_a_valid_max_item_param = %w(20 50 100).include?(params[:max_items])
+          @max_items = 20 unless is_a_valid_max_item_param
+          @max_items ||= params[:max_items].to_i
+          max_items = @max_items
+        end
+
+        jids[0..max_items].each do |jid|
           status = Sidekiq::Status::get_all jid
           next if !status || status.count < 2
           status = add_details_to_status(status)

--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -88,7 +88,7 @@ module Sidekiq::Status
           @max_items = 'all' if params[:max_items] == 'all'
           max_items = jids.size if @max_items == 'all'
         else
-          is_a_valid_max_item_param = Sidekiq::Status::Web.validate_option(params[:max_items])
+          is_a_valid_max_item_param = Sidekiq::Status::Web.validate_option(params[:max_items].to_i)
           @max_items = Sidekiq::Status::Web.default_max_items unless is_a_valid_max_item_param
           @max_items ||= params[:max_items].to_i
           max_items = @max_items

--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -58,7 +58,7 @@ module Sidekiq::Status
           max_items = @max_items
         end
 
-        jids[0..max_items].each do |jid|
+        jids[0..max_items-1].each do |jid|
           status = Sidekiq::Status::get_all jid
           next if !status || status.count < 2
           status = add_details_to_status(status)

--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -6,6 +6,42 @@ module Sidekiq::Status
     # Location of Sidekiq::Status::Web view templates
     VIEW_PATH = File.expand_path('../../../web/views', __FILE__)
 
+    STATUS_PAGINATION_OPTIONS = [20, 50, 100].freeze
+
+    class << self
+      def number_of_items_options=(options = STATUS_PAGINATION_OPTIONS)
+        unless validate_pagination_options(options)
+          raise ArgumentError.new('status pagination options must be an Array of Integer values')
+        end
+        @number_of_items_options = options
+      end
+
+      def number_of_items_options
+        @number_of_items_options ||= STATUS_PAGINATION_OPTIONS
+      end
+
+      def default_max_items=(default_max_items = 20)
+        @default_max_items = default_max_items
+      end
+
+      def default_max_items
+        @default_max_items ||= 20
+      end
+
+      def validate_pagination_options(options)
+        result = true
+        return false unless options.is_a?(Array) && !options.empty?
+        options.each do |value|
+          result = false unless value.to_i.is_a?(Integer)
+        end
+        result
+      end
+
+      def validate_option(option)
+        number_of_items_options.include?(option)
+      end
+    end
+
     # @param [Sidekiq::Web] app
     def self.registered(app)
       app.helpers do
@@ -52,13 +88,14 @@ module Sidekiq::Status
           @max_items = 'all' if params[:max_items] == 'all'
           max_items = jids.size if @max_items == 'all'
         else
-          is_a_valid_max_item_param = %w(20 50 100).include?(params[:max_items])
-          @max_items = 20 unless is_a_valid_max_item_param
+          is_a_valid_max_item_param = Sidekiq::Status::Web.validate_option(params[:max_items])
+          @max_items = Sidekiq::Status::Web.default_max_items unless is_a_valid_max_item_param
           @max_items ||= params[:max_items].to_i
           max_items = @max_items
         end
 
-        jids[0..max_items-1].each do |jid|
+        (0..max_items-1).each do |idx|
+          jid = jids[idx]
           status = Sidekiq::Status::get_all jid
           next if !status || status.count < 2
           status = add_details_to_status(status)

--- a/web/views/statuses.erb
+++ b/web/views/statuses.erb
@@ -36,7 +36,7 @@
   <ul class="list-unstyled">
   <% Sidekiq::Status::Web.number_of_items_options.each do |option| %>
     <li  data-items="20" class="col-sm-1">
-      <a href="<%=root_path %>statuses?max_items=<%= option %>" class="btn btn-sm <%=@max_items.eql?(option) ? 'btn-primary' : '' %>">
+      <a href="<%=root_path %>statuses?max_items=<%= option %>" class="btn btn-sm <%=@max_items.to_s.eql?(option.to_s) ? 'btn-primary' : '' %>">
         <span><%= option %></span>
       </a>
     </li>

--- a/web/views/statuses.erb
+++ b/web/views/statuses.erb
@@ -34,21 +34,13 @@
 <h3 class="wi">Recent job statuses</h3>
 <div class="max-items col-sm-3 col-sm-offset-9">
   <ul class="list-unstyled">
+  <% Sidekiq::Status::Web.number_of_items_options.each do |option| %>
     <li  data-items="20" class="col-sm-1">
-      <a href="<%=root_path %>statuses?max_items=20" class="btn btn-sm <%=@max_items.eql?(20) ? 'btn-primary' : '' %>">
-        <span>20</span>
+      <a href="<%=root_path %>statuses?max_items=<%= option %>" class="btn btn-sm <%=@max_items.eql?(option) ? 'btn-primary' : '' %>">
+        <span><%= option %></span>
       </a>
     </li>
-    <li  data-items="50" class="col-sm-1">
-      <a href="<%=root_path %>statuses?max_items=50" class="btn btn-sm <%=@max_items.eql?(50) ? 'btn-primary' : '' %>">
-        <span>50</span>
-      </a>
-    </li>
-    <li data-items="100" class="col-sm-1">
-      <a href="<%=root_path %>statuses?max_items=100" class="btn btn-sm <%=@max_items.eql?(100) ? 'btn-primary' : '' %>">
-        <span>100</span>
-      </a>
-    </li>
+  <% end %>
     <li data-items="all" class="col-sm-1">
       <a href="<%=root_path %>statuses?max_items=all" class="btn btn-sm <%=@max_items.eql?('all') ? 'btn-primary' : '' %>">
         <span>All</span>

--- a/web/views/statuses.erb
+++ b/web/views/statuses.erb
@@ -16,6 +16,12 @@
 .header{
   text-align: center;
 }
+.max-items{
+  margin-bottom: 20px;
+}
+.max-items ul > li {
+  margin-right: 20px;
+}
 .header_update_time{
   width: 10%;
 }
@@ -26,6 +32,30 @@
 </style>
 
 <h3 class="wi">Recent job statuses</h3>
+<div class="max-items col-sm-3 col-sm-offset-9">
+  <ul class="list-unstyled">
+    <li  data-items="20" class="col-sm-1">
+      <a href="<%=root_path %>statuses?max_items=20" class="btn btn-sm <%=@max_items.eql?(20) ? 'btn-primary' : '' %>">
+        <span>20</span>
+      </a>
+    </li>
+    <li  data-items="50" class="col-sm-1">
+      <a href="<%=root_path %>statuses?max_items=50" class="btn btn-sm <%=@max_items.eql?(50) ? 'btn-primary' : '' %>">
+        <span>50</span>
+      </a>
+    </li>
+    <li data-items="100" class="col-sm-1">
+      <a href="<%=root_path %>statuses?max_items=100" class="btn btn-sm <%=@max_items.eql?(100) ? 'btn-primary' : '' %>">
+        <span>100</span>
+      </a>
+    </li>
+    <li data-items="all" class="col-sm-1">
+      <a href="<%=root_path %>statuses?max_items=all" class="btn btn-sm <%=@max_items.eql?('all') ? 'btn-primary' : '' %>">
+        <span>All</span>
+      </a>
+    </li>
+  </ul>
+</div>
 <table class="table table-hover table-bordered table-striped table-white">
   <tr>
     <% @headers.each do |h| %>


### PR DESCRIPTION
This PR enable the use of max_items parameter. This is useful when you need to get the response in few seconds and your system is running a huge number of jobs. If you have Cloudflare you usually get a timeout error.

Four small buttons ( 20 50 100 All) are added on to of the jobs table.

![sidekiq_status_max_items](https://cloud.githubusercontent.com/assets/943152/22461591/1b93159e-e7aa-11e6-9028-65691a178a7e.png)

Note: I was not able to add a proper specs to add 150 jobs and test the number of rows inside the table. If you can show me an example how to test this i'll follow your examples and add all the specs needed to cover all cases. 