### PR TITLE
Stub proper method in testing

### DIFF
--- a/lib/sidekiq-status/testing/inline.rb
+++ b/lib/sidekiq-status/testing/inline.rb
@@ -11,6 +11,10 @@ module Sidekiq
     def store_status(id, status, expiration = nil, redis_pool=nil)
       'ok'
     end
+    
+    def store_for_id(id, status_updates, expiration = nil, redis_pool=nil)
+      'ok'
+    end
   end
 end
 


### PR DESCRIPTION
Problem:
```
  Redis::CannotConnectError:
       Error connecting to Redis on 127.0.0.1:6379 (Errno::ECONNREFUSED)
     # /bundle/2.3/gems/redis-3.3.5/lib/redis/client.rb:345:in `rescue in establish_connection'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis/client.rb:331:in `establish_connection'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis/client.rb:101:in `block in connect'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis/client.rb:293:in `with_reconnect'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis/client.rb:100:in `connect'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis/client.rb:364:in `ensure_connected'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis/client.rb:221:in `block in process'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis/client.rb:306:in `logging'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis/client.rb:220:in `process'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis/client.rb:187:in `call_pipelined'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis/client.rb:157:in `block in call_pipeline'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis/client.rb:293:in `with_reconnect'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis/client.rb:155:in `call_pipeline'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis.rb:2304:in `block in multi'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis.rb:58:in `block in synchronize'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis.rb:58:in `synchronize'
     # /bundle/2.3/gems/redis-3.3.5/lib/redis.rb:2296:in `multi'
     # /bundle/2.3/gems/sidekiq-status-0.6.0/lib/sidekiq-status/storage.rb:16:in `block in store_for_id'
     # /bundle/2.3/gems/sidekiq-status-0.6.0/lib/sidekiq-status/storage.rb:106:in `block in redis_connection'
     # /bundle/2.3/gems/sidekiq-5.0.4/lib/sidekiq.rb:95:in `block in redis'
     # /bundle/2.3/gems/connection_pool-2.2.1/lib/connection_pool.rb:64:in `block (2 levels) in with'
     # /bundle/2.3/gems/connection_pool-2.2.1/lib/connection_pool.rb:63:in `handle_interrupt'
     # /bundle/2.3/gems/connection_pool-2.2.1/lib/connection_pool.rb:63:in `block in with'
     # /bundle/2.3/gems/connection_pool-2.2.1/lib/connection_pool.rb:60:in `handle_interrupt'
     # /bundle/2.3/gems/connection_pool-2.2.1/lib/connection_pool.rb:60:in `with'
     # /bundle/2.3/gems/sidekiq-5.0.4/lib/sidekiq.rb:92:in `redis'
     # /bundle/2.3/gems/sidekiq-status-0.6.0/lib/sidekiq-status/storage.rb:105:in `redis_connection'
     # /bundle/2.3/gems/sidekiq-status-0.6.0/lib/sidekiq-status/storage.rb:15:in `store_for_id'
     # /bundle/2.3/gems/sidekiq-status-0.6.0/lib/sidekiq-status/worker.rb:14:in `store'
```