### PR TITLE
Middleware should respect Sidekiq::Status::Worker & custom ActiveJob expirations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-Version 0.7.0
+**master**
++ Properly ignores jobs that do not have `Sidekiq::Status::Worker` included
++ Honors custom job expirations for ActiveJob jobs
+
+**Version 0.7.0**
 + Sidekiq 4.2 and 5 now supported
 + Added full support for ActiveJob
 + Updated Web UI
@@ -8,7 +12,7 @@ Version 0.7.0
   + Times now display using natural language via ChronicDuration
 + Test suite fixed
 
-Version 0.6.0
+**Version 0.6.0**
 + Updated Web UI
   + Will have all job statuses, previously it was showing only :working status
   + Bootstrap lables instead of badges for status
@@ -17,17 +21,17 @@ Version 0.6.0
 + Added way to specify :expiration for Sidekiq::Status::ClientMiddleware
 + Bug fixes & Code cleaup
 
-Version 0.5.3
+**Version 0.5.3**
 + some tweaks in web UI, separate redis namespace
 
-Version 0.5.2
+**Version 0.5.2**
 + Sidekiq versions up to 3.3.* supported, jobs sorting options in web UI, more ruby versions
 
-Version 0.5.1
+**Version 0.5.1**
 + dependencies versions requirements relaxed
 
-Version 0.5.0
+**Version 0.5.0**
 + Sidekiq v3 support, redis pools support
 
-Version 0.4.0
+**Version 0.4.0**
 + WebUI added, per-worker expiration setting enabled

--- a/README.md
+++ b/README.md
@@ -68,11 +68,12 @@ Sidekiq.configure_server do |config|
 end
 ```
 
-After that you can use your jobs as usual. You may also include the `Sidekiq::Status::Worker` module in your jobs if you want the additional functionality of tracking progress and storing / retrieving job data.
+After that you can use your jobs as usual. You need to also include the `Sidekiq::Status::Worker` module in your jobs if you want the additional functionality of tracking progress and storing / retrieving job data.
 
 ``` ruby
 class MyJob
   include Sidekiq::Worker
+  include Sidekiq::Status::Worker # enables job status tracking
 
   def perform(*args)
   # your code goes here
@@ -80,11 +81,14 @@ class MyJob
 end
 ```
 
+As of version 0.8.0, _only jobs that include `Sidekiq::Status::Worker`_ will have their statuses tracked. Previous versions of this gem used to track statuses for all jobs, even when `Sidekiq::Status::Worker` was not included.
+
 To overwrite expiration on a per-worker basis, write an expiration method like the one below:
 
 ``` ruby
 class MyJob
   include Sidekiq::Worker
+  include Sidekiq::Status::Worker # enables job status tracking
 
   def expiration
     @expiration ||= 60 * 60 * 24 * 30 # 30 days
@@ -149,7 +153,7 @@ end
 
 ### Tracking Progress and Storing Data
 
-sidekiq-status comes with a feature that allows you to track the progress of a job, as well as store and retrieve any custom data related to a job. To use, just include the `Sidekiq::Status::Worker` module in your jobs.
+sidekiq-status comes with a feature that allows you to track the progress of a job, as well as store and retrieve any custom data related to a job.
 
 ``` ruby
 class MyJob
@@ -217,6 +221,8 @@ This gem provides an extension to Sidekiq's web interface with an index at `/sta
 As of 0.7.0, status information for an individual job may be found at `/statuses/:job_id`.
 
 ![Sidekiq Status Web](web/sidekiq-status-single-web.png)
+
+As of 0.8.0, only jobs that include `Sidekiq::Status::Worker` will be reported in the web interface.
 
 #### Adding the Web Interface
 

--- a/lib/sidekiq-status/client_middleware.rb
+++ b/lib/sidekiq-status/client_middleware.rb
@@ -21,7 +21,7 @@ module Sidekiq::Status
 
       # Determine the actual job class
       klass = msg["args"][0]["job_class"] || worker_class rescue worker_class
-      job_class = Module.const_get(klass)
+      job_class = klass.is_a?(Class) ? klass : Module.const_get(klass)
 
       # Store data if the job is a Sidekiq::Status::Worker
       if job_class.ancestors.include?(Sidekiq::Status::Worker)

--- a/lib/sidekiq-status/server_middleware.rb
+++ b/lib/sidekiq-status/server_middleware.rb
@@ -37,7 +37,7 @@ module Sidekiq::Status
       end
 
       # Determine job expiration
-      expiry = job_class.new.expiration rescue @expiration
+      expiry = job_class.new.expiration || @expiration rescue @expiration
 
       store_status worker.jid, :working,  expiry
       yield

--- a/lib/sidekiq-status/server_middleware.rb
+++ b/lib/sidekiq-status/server_middleware.rb
@@ -29,7 +29,7 @@ module Sidekiq::Status
       klass = msg["args"][0]["job_class"] || msg["class"] rescue msg["class"]
       job_class = klass.is_a?(Class) ? klass : Module.const_get(klass)
 
-      # Bypass uless this is a Sidekiq::Status::Worker job
+      # Bypass unless this is a Sidekiq::Status::Worker job
       unless job_class.ancestors.include?(Sidekiq::Status::Worker)
         yield
         return

--- a/lib/sidekiq-status/server_middleware.rb
+++ b/lib/sidekiq-status/server_middleware.rb
@@ -27,7 +27,7 @@ module Sidekiq::Status
 
       # Determine the actual job class
       klass = msg["args"][0]["job_class"] || msg["class"] rescue msg["class"]
-      job_class = Module.const_get(klass)
+      job_class = klass.is_a?(Class) ? klass : Module.const_get(klass)
 
       # Bypass uless this is a Sidekiq::Status::Worker job
       unless job_class.ancestors.include?(Sidekiq::Status::Worker)

--- a/spec/lib/sidekiq-status_spec.rb
+++ b/spec/lib/sidekiq-status_spec.rb
@@ -185,12 +185,12 @@ describe Sidekiq::Status do
 
     def run_2_jobs!
       start_server(:expiration => expiration_param) do
-        expect(capture_status_updates(12) {
+        expect(capture_status_updates(6) {
           expect(StubJob.perform_async).to eq(plain_sidekiq_job_id)
           NoStatusConfirmationJob.perform_async(1)
           expect(StubJob.perform_async).to eq(job_id_1)
           NoStatusConfirmationJob.perform_async(2)
-        }).to match_array([plain_sidekiq_job_id, job_id_1] * 6)
+        }).to match_array([plain_sidekiq_job_id, job_id_1] * 3)
       end
     end
 

--- a/spec/support/test_jobs.rb
+++ b/spec/support/test_jobs.rb
@@ -10,6 +10,12 @@ class StubJob
   end
 end
 
+class ExpiryJob < StubJob
+  def expiration
+    15
+  end
+end
+
 class LongJob < StubJob
   def perform(*args)
     sleep args[0] || 0.25
@@ -73,7 +79,7 @@ class RetriedJob < StubJob
   def perform()
     Sidekiq.redis do |conn|
       key = "RetriedJob_#{jid}"
-      sleep 1
+      sleep 0.25
       unless conn.exists key
         conn.set key, 'tried'
         raise StandardError


### PR DESCRIPTION
References #106. Fixes #111.

**Changes:**
 - [x] Ensures middleware only pushes status information for jobs that include `Sidekiq::Status::Worker`
 - [x] Properly honors `#expiration` settings for `ActiveJob` jobs
 - [x] Updates test suite to account for the above changes