### PR TITLE
Fix inline testing not working due to incorrect namespacing

### DIFF
--- a/lib/sidekiq-status/testing/inline.rb
+++ b/lib/sidekiq-status/testing/inline.rb
@@ -5,15 +5,15 @@ module Sidekiq
         :complete
       end
     end
-  end
-  
-  module Storage
-    def store_status(id, status, expiration = nil, redis_pool=nil)
-      'ok'
-    end
-    
-    def store_for_id(id, status_updates, expiration = nil, redis_pool=nil)
-      'ok'
+
+    module Storage
+      def store_status(id, status, expiration = nil, redis_pool=nil)
+        'ok'
+      end
+
+      def store_for_id(id, status_updates, expiration = nil, redis_pool=nil)
+        'ok'
+      end
     end
   end
 end


### PR DESCRIPTION
When calling `require 'sidekiq-status/testing/inline'` we expect that calls to `store_status` and `store_for_id` be mapped to the contents of `sidekiq-status/testing/inline.rb`. However, the namespace for the calls in `inline.rb` is `Sidekiq::Storage` which does not match the namespace of `Sidekiq::Status::Storage` defined in `storage.rb`. As a result, even when requiring the inline testing, calls to `store_status` and `store_for_id` still map into `storage.rb`. This commit fixes that so that calls are properly redirected to `inline.rb`.