### PR TITLE
Use Scan Rather Than Keys When Getting Status Job IDs

### DIFF
--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -78,7 +78,7 @@ module Sidekiq::Status
         jids = Sidekiq.redis do |conn|
           conn.scan_each(match: 'sidekiq:status:*', count: 100).map do |key|
             key.split(':').last
-          end
+          end.uniq
         end
         @statuses = []
 

--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -75,8 +75,11 @@ module Sidekiq::Status
 
       app.get '/statuses' do
 
-        namespace_jids = Sidekiq.redis{ |conn| conn.keys('sidekiq:status:*') }
-        jids = namespace_jids.map{ |id_namespace| id_namespace.split(':').last }
+        jids = Sidekiq.redis do |conn|
+          conn.scan_each(match: 'sidekiq:status:*', count: 100).map do |key|
+            key.split(':').last
+          end
+        end
         @statuses = []
 
         jids.each do |jid|


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/utgarda/sidekiq-status/issues/132) the method `keys` can be tough on Redis. I went ahead and replaced it with a scan combined with the [match option](https://redis.io/commands/scan#the-match-option) which will filter down the keys. I ran all the specs locally and they passed. Given this is an implementation detail I didn't think additional specs were necessary.  Let me know what you think! Thanks! 