### PR TITLE
Custom data on status page

### DIFF
--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -8,6 +8,7 @@ module Sidekiq::Status
 
     DEFAULT_PER_PAGE_OPTS = [25, 50, 100].freeze
     DEFAULT_PER_PAGE = 25
+    COMMON_STATUS_HASH_KEYS = %w(update_time jid status worker args label pct_complete)
 
     class << self
       def per_page_opts= arr
@@ -47,7 +48,16 @@ module Sidekiq::Status
         def add_details_to_status(status)
           status['label'] = status_label(status['status'])
           status["pct_complete"] ||= pct_complete(status)
+          status["web"] = process_custom_data(status)
           return status
+        end
+
+        def process_custom_data(hash)
+          hash.reject { |key, _| COMMON_STATUS_HASH_KEYS.include?(key) }
+        end
+
+        def humanize_key(key)
+          key.tr('_', ' ').capitalize
         end
 
         def pct_complete(status)

--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -8,7 +8,7 @@ module Sidekiq::Status
 
     DEFAULT_PER_PAGE_OPTS = [25, 50, 100].freeze
     DEFAULT_PER_PAGE = 25
-    COMMON_STATUS_HASH_KEYS = %w(update_time jid status worker args label pct_complete)
+    COMMON_STATUS_HASH_KEYS = %w(update_time jid status worker args label pct_complete total at message)
 
     class << self
       def per_page_opts= arr

--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -48,7 +48,7 @@ module Sidekiq::Status
         def add_details_to_status(status)
           status['label'] = status_label(status['status'])
           status["pct_complete"] ||= pct_complete(status)
-          status["web"] = process_custom_data(status)
+          status["custom"] = process_custom_data(status)
           return status
         end
 

--- a/spec/lib/sidekiq-status/web_spec.rb
+++ b/spec/lib/sidekiq-status/web_spec.rb
@@ -48,4 +48,15 @@ describe 'sidekiq status web' do
     expect(last_response).to be_not_found
     expect(last_response.body).to match(/That job can't be found/)
   end
+
+  it 'shows a single job in progress' do
+    capture_status_updates(2) do
+      CustomDataJob.perform_async
+    end
+
+    get "/statuses/#{job_id}"
+    expect(last_response).to be_ok
+    expect(last_response.body).to match(/Mister cat/)
+    expect(last_response.body).to match(/meow/)
+  end
 end

--- a/spec/lib/sidekiq-status/web_spec.rb
+++ b/spec/lib/sidekiq-status/web_spec.rb
@@ -44,7 +44,7 @@ describe 'sidekiq status web' do
   end
 
   it 'shows custom data for a single job' do
-    capture_status_updates(2) do
+    capture_status_updates(3) do
       CustomDataJob.perform_async
     end
 

--- a/spec/lib/sidekiq-status/web_spec.rb
+++ b/spec/lib/sidekiq-status/web_spec.rb
@@ -43,13 +43,7 @@ describe 'sidekiq status web' do
     expect(last_response.body).to match(/working/)
   end
 
-  it 'show an error when the requested job ID is not found' do
-    get '/statuses/12345'
-    expect(last_response).to be_not_found
-    expect(last_response.body).to match(/That job can't be found/)
-  end
-
-  it 'shows a single job in progress' do
+  it 'shows custom data for a single job' do
     capture_status_updates(2) do
       CustomDataJob.perform_async
     end
@@ -58,5 +52,11 @@ describe 'sidekiq status web' do
     expect(last_response).to be_ok
     expect(last_response.body).to match(/Mister cat/)
     expect(last_response.body).to match(/meow/)
+  end
+
+  it 'show an error when the requested job ID is not found' do
+    get '/statuses/12345'
+    expect(last_response).to be_not_found
+    expect(last_response.body).to match(/That job can't be found/)
   end
 end

--- a/spec/support/test_jobs.rb
+++ b/spec/support/test_jobs.rb
@@ -31,6 +31,13 @@ class DataJob < StubJob
   end
 end
 
+class CustomDataJob < StubJob
+  def perform
+    store({mister_cat: 'meow'})
+  end
+end
+
+
 class ProgressJob < StubJob
   def perform
     total 500

--- a/spec/support/test_jobs.rb
+++ b/spec/support/test_jobs.rb
@@ -34,9 +34,9 @@ end
 class CustomDataJob < StubJob
   def perform
     store({mister_cat: 'meow'})
+    sleep 0.5
   end
 end
-
 
 class ProgressJob < StubJob
   def perform

--- a/web/views/status.erb
+++ b/web/views/status.erb
@@ -65,6 +65,20 @@
         </p>
       </div>
     </div>
+
+    <% if @status["web"].any? %>
+      <hr>
+      <% @status["web"].each do |key, val| %>
+        <div class="row">
+          <div class="col-sm-2">
+            <strong><%= humanize_key(key) %></strong>
+          </div>
+          <div class="col-sm-10">
+            <p><%= val || "<i>none</i>" %></p>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
   </div>
 </div>
 

--- a/web/views/status.erb
+++ b/web/views/status.erb
@@ -66,9 +66,9 @@
       </div>
     </div>
 
-    <% if @status["web"].any? %>
+    <% if @status["custom"].any? %>
       <hr>
-      <% @status["web"].each do |key, val| %>
+      <% @status["custom"].each do |key, val| %>
         <div class="row">
           <div class="col-sm-2">
             <strong><%= humanize_key(key) %></strong>

--- a/web/views/status.erb
+++ b/web/views/status.erb
@@ -74,7 +74,11 @@
             <strong><%= humanize_key(key) %></strong>
           </div>
           <div class="col-sm-10">
-            <p><%= val || "<i>none</i>" %></p>
+            <% if val && val.include?("\n") %>
+              <pre><%= val %></pre>
+            <% else  %>
+              <p><%= val || "<i>none</i>" %></p>
+            <% end %>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
## What does it do?

- Displays custom data on job status page
- Corrects the description of the custom data it block in specs
- Excludes `total`, `at`, and `message` from custom data display
- Changes custom data key for web view from `"web"` to `"custom"`
- Adds preformat (`<pre>`) support for custom data values that span multiple lines

## What else do you need to know?

This expands on @kelevro's work to add custom data to the individual status page for a job by re-syncing with the master branch, addressing some of the concerns in the code review, and (_hopefully_) turning the test suite green.

## Related Issues

Closes #133 

## Screenshots

<img width="1209" alt="DEVELOPMENT  Sidekiq 2019-03-08 15-00-54" src="https://user-images.githubusercontent.com/740/54058695-dfba7100-41b3-11e9-906c-4aa554fe0bdf.png">

<img width="1198" alt="DEVELOPMENT  Sidekiq 2019-03-08 15-02-48" src="https://user-images.githubusercontent.com/740/54058699-e21ccb00-41b3-11e9-8f77-ea2bd9e3fb21.png">

