### PR TITLE
Adds support for status filtering

### DIFF
--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -105,6 +105,10 @@ module Sidekiq::Status
           @statuses = @statuses.sort { |y,x| (x[sort_by] <=> y[sort_by]) || 1 }
         end
 
+        if params[:status] && params[:status] != "all"
+          @statuses = @statuses.select {|job_status| job_status["status"] == params[:status] }
+        end
+
         # Sidekiq pagination
         @total_size = @statuses.count
         @count = params[:per_page] ? params[:per_page].to_i : Sidekiq::Status::Web.default_per_page
@@ -158,7 +162,7 @@ end
 
 require 'sidekiq/web' unless defined?(Sidekiq::Web)
 Sidekiq::Web.register(Sidekiq::Status::Web)
-["per_page", "sort_by", "sort_dir"].each do |key|
+["per_page", "sort_by", "sort_dir", "status"].each do |key|
   Sidekiq::WebHelpers::SAFE_QPARAMS.push(key)
 end
 if Sidekiq::Web.tabs.is_a?(Array)

--- a/spec/lib/sidekiq-status/web_spec.rb
+++ b/spec/lib/sidekiq-status/web_spec.rb
@@ -31,6 +31,27 @@ describe 'sidekiq status web' do
     expect(last_response.body).to match(/working/)
   end
 
+  it 'allows filtering the list of jobs by status' do
+    capture_status_updates(2) do
+      LongJob.perform_async(0.5)
+    end
+
+    get '/statuses?status=working'
+    expect(last_response).to be_ok
+    expect(last_response.body).to match(/#{job_id}/)
+    expect(last_response.body).to match(/LongJob/)
+    expect(last_response.body).to match(/working/)
+  end
+
+  it 'allows filtering the list of jobs by completed status' do
+    capture_status_updates(2) do
+      LongJob.perform_async(0.5)
+    end
+    get '/statuses?status=completed'
+    expect(last_response).to be_ok
+    expect(last_response.body).to_not match(/LongJob/)
+  end
+
   it 'shows a single job in progress' do
     capture_status_updates(2) do
       LongJob.perform_async(1, 'another argument')

--- a/web/views/statuses.erb
+++ b/web/views/statuses.erb
@@ -38,7 +38,7 @@
   display: flex;
   align-items: center;
 }
-.nav-container .per-page {
+.nav-container .per-page, .filter-status {
   display: flex;
   align-items: center;
   margin: 20px 0 20px 10px;
@@ -57,6 +57,15 @@ function setPerPage(select){
   <h3 class="wi">Recent job statuses</h3>
   <div class="nav-container">
     <%= erb :_paging, locals: { url: "#{root_path}statuses" } %>
+    <div class="filter-status">
+      Filter Status:
+      <select class="form-control" onchange="setPerPage(this)">
+        <% (['all', 'complete', 'failed', 'interrupted', 'queued', 'retrying', 'stopped', 'working']).each do |status| %>
+          <option data-url="?<%= qparams(status: status)%>" value="<%= status %>" <%= 'selected="selected"' if status == (params[:status]) %>><%= status %></option>
+        <% end %>
+      </select>
+    </div>
+
     <div class="per-page">
       Per page:
       <select class="form-control" onchange="setPerPage(this)">


### PR DESCRIPTION
## What does it do?
- Adds a select dropdown for filtering status messages by job status.
## What else do you need to know?
- This PR resolves #123 
- Since sorting of statuses is done in ruby, I did filtering in a similar manner.
## Screenshots
![Screen Shot 2019-05-13 at 10 17 25 AM](https://user-images.githubusercontent.com/2698/57638599-589ac800-756b-11e9-88ae-d7c685b4e560.png)
![Screen Shot 2019-05-13 at 10 16 43 AM](https://user-images.githubusercontent.com/2698/57638604-5c2e4f00-756b-11e9-9950-63717a100ff6.png)
![Screen Shot 2019-05-13 at 10 16 29 AM](https://user-images.githubusercontent.com/2698/57638610-60f30300-756b-11e9-95ad-c2c41b1951ef.png)
