### PR TITLE
Do not record status for exceptions unless Sidekiq::Status::Worker is included

### DIFF
--- a/lib/sidekiq-status/server_middleware.rb
+++ b/lib/sidekiq-status/server_middleware.rb
@@ -61,7 +61,7 @@ module Sidekiq::Status
           status = :retrying
         end
       end
-      store_status worker.jid, status, expiry
+      store_status(worker.jid, status, expiry) if job_class && job_class.ancestors.include?(Sidekiq::Status::Worker)
       raise
     end
 

--- a/spec/support/test_jobs.rb
+++ b/spec/support/test_jobs.rb
@@ -10,6 +10,16 @@ class StubJob
   end
 end
 
+class StubNoStatusJob
+  include Sidekiq::Worker
+
+  sidekiq_options 'retry' => false
+
+  def perform(*args)
+  end
+end
+
+
 class ExpiryJob < StubJob
   def expiration
     15
@@ -69,6 +79,12 @@ class FailingJob < StubJob
   end
 end
 
+class FailingNoStatusJob < StubNoStatusJob
+  def perform
+    raise StandardError
+  end
+end
+
 class RetryAndFailJob < StubJob
   sidekiq_options retry: 1
 
@@ -78,6 +94,12 @@ class RetryAndFailJob < StubJob
 end
 
 class FailingHardJob < StubJob
+  def perform
+    raise Exception
+  end
+end
+
+class FailingHardNoStatusJob < StubNoStatusJob
   def perform
     raise Exception
   end


### PR DESCRIPTION
## What does it do?
* Only record status for an exception if the job that has the exception includes the `Sidekiq::Status::Worker`.
## What else do you need to know?
* Fixes #127.
